### PR TITLE
Enhance CI workflow in dotnet-build.yml

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -5,10 +5,16 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  release:
+    types: [published]
+  workflow_dispatch:
+  # Uncomment below for tag triggers
+  # push:
+  #   tags:
+  #     - '*'
 
 jobs:
   build:
-
     runs-on: windows-latest
 
     strategy:
@@ -19,6 +25,18 @@ jobs:
     steps:
       - name: 🛎️ Checkout Repository
         uses: actions/checkout@v3
+
+      - name: ⚡️ Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.nuget/packages
+            **/obj/project.assets.json
+          key: nuget-${{ runner.os }}-${{ matrix.dotnet-version }}-${{ hashFiles('**/*.csproj') }}
+          restore-keys: |
+            nuget-${{ runner.os }}-${{ matrix.dotnet-version }}-
+            nuget-${{ runner.os }}-
+            nuget-
 
       - name: 🧰 Setup .NET ${{ matrix.dotnet-version }}
         uses: actions/setup-dotnet@v4
@@ -31,16 +49,33 @@ jobs:
       - name: 🛠️ Build Solution
         run: dotnet build --no-restore --configuration Release
 
+      - name: 🧪 Run Tests
+        run: dotnet test --no-build --configuration Release
+        continue-on-error: true
+
       - name: 📦 Collect Build Artifacts
         if: success()
         run: |
           mkdir -p output
-          find . -type f -path "*/bin/Release/*.exe" -exec cp {} output/ \;
-        shell: bash
+          Get-ChildItem -Path . -Filter *.exe -Recurse | Where-Object { $_.FullName -match '\\bin\\Release\\' } | Copy-Item -Destination output -Force
+        shell: pwsh
 
-      - name: 📤 Upload Artifacts to GitHub
+      - name: 📑 Publish App
+        if: success()
+        run: |
+          dotnet publish -c Release -r win-x64 --output published
+        shell: pwsh
+
+      - name: 📤 Upload Build Artifacts
         if: success()
         uses: actions/upload-artifact@v4
         with:
           name: eShift-Desktop-Build
           path: output
+
+      - name: 📤 Upload Published App
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: eShift-Desktop-Published
+          path: published


### PR DESCRIPTION
Updated `dotnet-build.yml` to add caching for NuGet packages, run tests, and manage build artifacts. Introduced publishing steps and support for manual triggers with `workflow_dispatch`. Improved overall artifact management and testing processes.